### PR TITLE
Bikeshed fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,7 @@ Abstract:
 Indent: 2
 Markup Shorthands: markdown on
 Inline Github Issues: true
+!Issue Tracking: <a href="https://github.com/w3c/geolocation-sensor/issues">Issues</a>
 !Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/geolocation-sensor">web-platform-tests</a>
 !Polyfills: <a href="https://github.com/kenchris/sensor-polyfills/blob/master/src/geolocation-sensor.js">geolocation-sensor.js</a><br><a href="https://github.com/w3c/sensors/blob/main/polyfills/geolocation.js">geolocation.js</a>
 Boilerplate: omit issues-index, omit conformance, omit feedback-header

--- a/index.bs
+++ b/index.bs
@@ -13,14 +13,15 @@ Status Text: <p class="note" role="note"><span>Note:</span> The work on the Geol
 Abstract:
   This specification defines the {{GeolocationSensor}} interface for obtaining
   the [=geolocation=] of the hosting device.
-!Participate: <a href="https://github.com/w3c/geolocation-sensor">GitHub</a> (<a href="https://github.com/w3c/geolocation-sensor/issues/new">new issue</a>, <a href="https://github.com/w3c/geolocation-sensor/issues">open issues</a>)
 Indent: 2
 Markup Shorthands: markdown on
 Inline Github Issues: true
-!Issue Tracking: <a href="https://github.com/w3c/geolocation-sensor/issues">Issues</a>
+Repository: w3c/geolocation-sensor
+Issue Tracking: Geolocation Sensor Issues Repository https://github.com/w3c/geolocation-sensor/issues
 !Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/geolocation-sensor">web-platform-tests</a>
 !Polyfills: <a href="https://github.com/kenchris/sensor-polyfills/blob/master/src/geolocation-sensor.js">geolocation-sensor.js</a><br><a href="https://github.com/w3c/sensors/blob/main/polyfills/geolocation.js">geolocation.js</a>
-Boilerplate: omit issues-index, omit conformance, omit feedback-header
+Boilerplate: omit issues-index, omit conformance, omit feedback-header, repository-issue-tracking no
+Include MDN Panels: if possible
 Ignored Vars: p, geo, key
 Default Biblio Status: current
 Note class: note


### PR DESCRIPTION
Fix the error in https://github.com/w3c/geolocation-sensor/runs/2714918586 :

```
      FATAL ERROR: Not all required metadata was provided:
          Must provide at least one 'Issue Tracking' entry.
       ✘  Did not generate, due to fatal errors
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/pull/46.html" title="Last updated on Jun 2, 2021, 5:10 AM UTC (f09b9ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/46/ac91fe7...f09b9ef.html" title="Last updated on Jun 2, 2021, 5:10 AM UTC (f09b9ef)">Diff</a>