### PR TITLE
Chore: update the SoTD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,12 +10,11 @@ Editor: Thomas Steiner 44965, Google Inc., https://google.com/
 Editor: Marijn Kruisselbrink 72440, Google Inc., https://google.com/
 Group: dap
 Status Text:
-  The Devices and Sensors Working Group is pursuing modern security and privacy
-  reviews for this specification in consideration of the amount of change in both
-  this specification and in privacy and security review practices since the
-  horizontal reviews took place. Similarly, the group is pursuing an update to the
-  Technical Architecture Group review for this specification to account for the
-  latest architectural review practices.
+  The Devices and Sensors Working Group will perform a round of self-review and
+  revisions on the security and privacy aspects of the API before
+  requesting horizontal review. Existing security and privacy issues can
+  be found <a
+  href="https://www.w3.org/PM/horizontal/review.html?shortname=geolocation-sensor">here</a>.
 Abstract:
   This specification defines the {{GeolocationSensor}} interface for obtaining
   the [=geolocation=] of the hosting device.


### PR DESCRIPTION
Because we haven't requested wide review for this spec, the description here ("since the horizontal reviews took place" and "an update to the Technical Architecture Group review") is not accurate.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/pull/51.html" title="Last updated on Aug 14, 2021, 9:08 AM UTC (0b1a2f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/51/cbddd7f...0b1a2f8.html" title="Last updated on Aug 14, 2021, 9:08 AM UTC (0b1a2f8)">Diff</a>