### PR TITLE
Make default allowlist normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -135,6 +135,8 @@ The <dfn>Geolocation Sensor</dfn> <a>sensor type</a>'s associated {{Sensor}} sub
 The <a>Geolocation Sensor</a> has an associated {{PermissionName}} which is
 <a for="PermissionName" enum-value>"geolocation"</a>.
 
+The <a>Geolocation Sensor</a> is a [=policy-controlled feature=] identified by the string "geolocation". Its [=default allowlist=] is `'self'`.
+
 A <dfn>latest geolocation reading</dfn> is a [=latest reading=] for a {{Sensor}} of
 <a>Geolocation Sensor</a> <a>sensor type</a>. It includes [=map/entries=] whose [=map/keys=]
 are "latitude", "longitude", "altitude", "accuracy", "altitudeAccuracy", "heading", "speed"


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/pull/52.html" title="Last updated on Sep 1, 2021, 3:22 PM UTC (bfe9937)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/52/b93e986...bfe9937.html" title="Last updated on Sep 1, 2021, 3:22 PM UTC (bfe9937)">Diff</a>