### PR TITLE
Rewrite Automation section after w3c/sensors#470

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,9 +44,6 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: security and privacy; url: security-and-privacy
     text: extensible; url: extensibility
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
-    text: automation
-    text: mock sensor type
-    text: mock sensor reading values
 urlPrefix: https://dom.spec.whatwg.org; spec: DOM
   type: dfn
     text: add the following abort steps; url: abortsignal-add
@@ -318,27 +315,29 @@ Abstract Operations {#abstract-operations}
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the [=geolocation=] of the hosting device for the purposes of
-testing a user agent's implementation of {{GeolocationSensor}} API.
 
-<h3 id="mock-geolocation-sensor-type">Mock Sensor Type</h3>
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Geolocation Sensor=]-specific virtual sensor metadata.
 
-The {{GeolocationSensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"geolocation"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`geolocation`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Geolocation Sensor=] and [=reading parsing algorithm=] is [=geolocation reading parsing algorithm=].
 
-<pre class="idl">
-  dictionary GeolocationReadingValues {
-    required double? latitude;
-    required double? longitude;
-    required double? altitude;
-    required double? accuracy;
-    required double? altitudeAccuracy;
-    required double? heading;
-    required double? speed;
-  };
-</pre>
+<h3 dfn>Geolocation reading parsing algorithm</h3>
+<div algorithm="geolocation reading parsing algorithm">
+    : input
+    :: |parameters|, a JSON {{Object}}
+    : output
+    :: A [=sensor reading=] or **undefined**
+
+    1.  Let |reading| be a new [=sensor reading=].
+    1.  Let |value| be a new [=sensor reading=].
+    1.  [=map/For each=] |key| in <a>latest geolocation reading</a> → let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
+        1.  If |value| is "undefined".
+            1.  Return "undefined".
+        1.  [=map/Set=] |reading|[|key|] to |value|.
+    1.  Return |reading|.
 
 Use Cases {#use-cases}
 =========

--- a/index.bs
+++ b/index.bs
@@ -322,7 +322,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 : [=map/key=]
 :: "`geolocation`"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Geolocation Sensor=] and [=reading parsing algorithm=] is [=geolocation reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Geolocation Sensor=] and [=reading parsing algorithm=] is the [=geolocation reading parsing algorithm=].
 
 <h3 dfn>Geolocation reading parsing algorithm</h3>
 <div algorithm="geolocation reading parsing algorithm">
@@ -332,12 +332,14 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
     :: A [=sensor reading=] or **undefined**
 
     1.  Let |reading| be a new [=sensor reading=].
-    1.  Let |value| be a new [=sensor reading=].
-    1.  [=map/For each=] |key| in <a>latest geolocation reading</a> → let |value| be the result of [=parse single-value number reading=] with |parameters| and |key|.
-        1.  If |value| is "undefined".
-            1.  Return "undefined".
-        1.  [=map/Set=] |reading|[|key|] to |value|.
+    1.  Let |keys| be the [=/list=] « "`latitude`", "`longitude`", "`altitude`", "`accuracy`", "`altitudeAccuracy`", "`heading`", "`speed`" ».
+    1.  [=list/For each=] |key| of |keys|
+        1.  Let |value| be the result of invoking [=parse single-value number reading=] with |parameters| and |key|.
+            1.  If |value| is **undefined**.
+                1.  Return **undefined**.
+        1.  [=map/Set=] |reading|[|key|] to |value|[|key|].
     1.  Return |reading|.
+</div>
 
 Use Cases {#use-cases}
 =========


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Geolocation Sensor spec to the changes:
* Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
* Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "geolocation" entry in MockSensorType and an appropriate virtual sensor metadata entry.

This is enough to integrate properly with the Generic Sensor spec and allow Geolocation virtual sensors to be created and used.

Fixes #55.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JuhaVainio/geolocation-sensor/pull/56.html" title="Last updated on Oct 26, 2023, 7:51 AM UTC (c80e900)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/56/56efb87...JuhaVainio:c80e900.html" title="Last updated on Oct 26, 2023, 7:51 AM UTC (c80e900)">Diff</a>