### PR TITLE
Adapt to virtual sensor changes in w3c/sensors#475

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,6 +134,9 @@ The <a>Geolocation Sensor</a> has an associated {{PermissionName}} which is
 
 The <a>Geolocation Sensor</a> is a [=policy-controlled feature=] identified by the string "geolocation". Its [=default allowlist=] is `'self'`.
 
+The <a>Geolocation Sensor</a> has an associated [=virtual sensor type=] which is
+"<code><dfn data-lt="geolocation virtual sensor type">geolocation</dfn></code>".
+
 A <dfn>latest geolocation reading</dfn> is a [=latest reading=] for a {{Sensor}} of
 <a>Geolocation Sensor</a> <a>sensor type</a>. It includes [=map/entries=] whose [=map/keys=]
 are "latitude", "longitude", "altitude", "accuracy", "altitudeAccuracy", "heading", "speed"
@@ -320,9 +323,9 @@ This section extends [[GENERIC-SENSOR#automation]] by providing [=Geolocation Se
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`geolocation`"
+:: "<code>[=geolocation virtual sensor type|geolocation=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Geolocation Sensor=] and [=reading parsing algorithm=] is the [=geolocation reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is the [=geolocation reading parsing algorithm=].
 
 <h3 dfn>Geolocation reading parsing algorithm</h3>
 <div algorithm="geolocation reading parsing algorithm">


### PR DESCRIPTION
w3c/sensors#475 removed the "virtual sensor type" item from the "virtual
sensor metadata" struct and turned it into a string that is referenced from
the automation bits as well as (optionally) defined by a sensor type.

Adapt to it here by removing mentions of `[=virtual sensor metadata/virtual
sensor type=]` from the spec and adding virtual sensor types to each sensor
type defined here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/geolocation-sensor/pull/57.html" title="Last updated on Nov 22, 2023, 4:03 PM UTC (330f9fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/57/7b4a298...rakuco:330f9fb.html" title="Last updated on Nov 22, 2023, 4:03 PM UTC (330f9fb)">Diff</a>