### PR TITLE
Update WGS84 href to archived link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,7 +66,7 @@ urlPrefix: http://w3c.github.io/hr-time/; spec: HR-TIME-2
     "authors": [
       "National Imagery and Mapping Agency"
     ],
-    "href": "http://earth-info.nga.mil/GandG/publications/tr8350.2/wgs84fin.pdf",
+    "href": "https://web.archive.org/web/20210304035901/https://earth-info.nga.mil/GandG/publications/tr8350.2/wgs84fin.pdf",
     "title": "Department of Defence World Geodetic System 1984",
     "status": "Technical Report, Third Edition",
     "publisher": "National Imagery and Mapping Agency"


### PR DESCRIPTION
The report is no longer available at the original URL but an archived version is available from the Internet Archive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/pull/69.html" title="Last updated on Feb 3, 2026, 6:27 PM UTC (89d3df0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/geolocation-sensor/69/25278e7...89d3df0.html" title="Last updated on Feb 3, 2026, 6:27 PM UTC (89d3df0)">Diff</a>